### PR TITLE
chore(linting): remove sort order plugin

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,9 +1,6 @@
 module.exports = {
   plugins: ["stylelint-scss"],
   extends: [
-    // Sets smacss property order
-    "stylelint-config-property-sort-order-smacss",
-
     // Sets official sass coding guidelines
     "stylelint-config-sass-guidelines",
 

--- a/packages/web-styles/package.json
+++ b/packages/web-styles/package.json
@@ -39,7 +39,6 @@
     "sass": "^1.49.7",
     "stylelint": "^14.3.0",
     "stylelint-config-prettier": "^9.0.3",
-    "stylelint-config-property-sort-order-smacss": "^8.0.0",
     "stylelint-config-sass-guidelines": "^9.0.1",
     "stylelint-prettier": "^2.0.0",
     "stylelint-scss": "^4.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,7 +237,6 @@ importers:
       sass: ^1.49.7
       stylelint: ^14.3.0
       stylelint-config-prettier: ^9.0.3
-      stylelint-config-property-sort-order-smacss: ^8.0.0
       stylelint-config-sass-guidelines: ^9.0.1
       stylelint-prettier: ^2.0.0
       stylelint-scss: ^4.1.0
@@ -258,7 +257,6 @@ importers:
       sass: 1.52.3
       stylelint: 14.9.1
       stylelint-config-prettier: 9.0.3_stylelint@14.9.1
-      stylelint-config-property-sort-order-smacss: 8.0.0_stylelint@14.9.1
       stylelint-config-sass-guidelines: 9.0.1_uyk3cwxn3favstz4untq233szu
       stylelint-prettier: 2.0.0_sw2z7wtsooeualpyi6xa2oke5m
       stylelint-scss: 4.2.0_stylelint@14.9.1
@@ -6666,10 +6664,6 @@ packages:
       postcss: ^8.4
     dependencies:
       postcss: 8.4.5
-    dev: true
-
-  /css-property-sort-order-smacss/2.1.3:
-    resolution: {integrity: sha1-uc8XU7NhLufRj+mSJPSDNT6jjlM=}
     dev: true
 
   /css-select/4.3.0:
@@ -15687,16 +15681,6 @@ packages:
       stylelint: '>=11.0.0'
     dependencies:
       stylelint: 14.9.1
-    dev: true
-
-  /stylelint-config-property-sort-order-smacss/8.0.0_stylelint@14.9.1:
-    resolution: {integrity: sha1-bpQVuroBWoLqt4bzsEYmZqTqHzw=}
-    peerDependencies:
-      stylelint: ^14.0.0
-    dependencies:
-      css-property-sort-order-smacss: 2.1.3
-      stylelint: 14.9.1
-      stylelint-order: 5.0.0_stylelint@14.9.1
     dev: true
 
   /stylelint-config-sass-guidelines/9.0.1_uyk3cwxn3favstz4untq233szu:


### PR DESCRIPTION
Property sort order is not practical at this stage of development. It's more hindering than useful.