### PR TITLE
fix(web-styles): publish the `dist` subdirectory

### DIFF
--- a/packages/web-styles/gulpfile.js
+++ b/packages/web-styles/gulpfile.js
@@ -1,10 +1,11 @@
+const fs = require('fs');
+const path = require('path');
 const gulp = require('gulp');
 const sass = require('sass');
 const gulpSass = require('gulp-sass')(sass);
 const gulpPostCss = require('gulp-postcss');
 const autoprefixer = require('autoprefixer');
 const options = require('./package.json').sass;
-
 /*
  * Copy task
  */
@@ -17,6 +18,27 @@ gulp.task("copy", () => {
       "./src/**/*.scss"
     ])
     .pipe(gulp.dest(options.outputDir));
+});
+
+/**
+ * Transform `package.json` of the published subdirectory
+ * 
+ * @remarks removes `publishConfig.directory`.
+ * The publish command runs against `publishConfig.directory`, so keeping the original path 
+ * would attempt publishing `web-styles/dist/dist` instead of `web-styles/dist`.
+ * 
+ */
+gulp.task('transform-package-json', (done) => {
+  const packageJson = require('./package.json');
+
+  delete packageJson.publishConfig.directory;
+
+  fs.writeFileSync(
+    path.join(options.outputDir, 'package.json'),
+    JSON.stringify(packageJson, null, 2),
+  );
+
+  done();
 });
 
 /*
@@ -65,5 +87,5 @@ gulp.task('watch', () => {
  */
 exports.default = gulp.task(
   "build",
-  gulp.parallel("copy", gulp.series("sass"))
+  gulp.parallel(gulp.series("copy", "transform-package-json"), gulp.series("sass"))
 );


### PR DESCRIPTION
Fixes the release workflow, which currently fails for the `web-styles` package because the publish command targets the `dist` folder, and `dist/package.json` points to `/dist/dist`, a directory that doesn't exist. Haven't looked into why looking for a `package.json` file in `dist/dist` doesn't produce an error, but transforming `dist/package.json` should fix the issue.

I have tried it out locally against `verdaccio` and `changeset publish` worked as expected. Feel free to close the PR if you have different plans for fixing the issue, I'm more interested in letting you know what went wrong.

### Why only `web-styles`?
Not 100% sure as to why `swisspost-intranet-header` doesn't have the same issue, but my guess is:
https://github.com/swisspost/common-web-frontend/blob/9203419db831f4eca3fca92b3f6b55194e0701e4/packages/angular-components/projects/swisspost-intranet-header/package.json#L9
When the `publish` command runs in `dist/swisspost-intranet-header`, it will end up pointing to the current directory, meaning that the relative path ends up being correct.

### Context
I had a similar issue as the one described in changesets/action#191 (in my case, the failure was TypeScript compilation errors). 

The difference is that mine would be fixable by changesets/changesets#844, because `pnpm` does redirect compilation errors to `stdout` by default (can be overridden by `use-stderr` in `.npmrc`).
