### PR TITLE
fix(styles): adds styles for progressbar in high-contrast-mode

### DIFF
--- a/.changeset/pink-dragons-carry.md
+++ b/.changeset/pink-dragons-carry.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/web-styles': patch
+---
+
+Adds styles for progressbar in high-contrast-mode

--- a/packages/web-styles/src/components/progress.scss
+++ b/packages/web-styles/src/components/progress.scss
@@ -20,7 +20,7 @@
 
   .progress-bar[class] {
     &,
-    & span {
+    span {
       background-color: Highlight !important;
     }
   }

--- a/packages/web-styles/src/components/progress.scss
+++ b/packages/web-styles/src/components/progress.scss
@@ -4,9 +4,24 @@
 @use '../themes/bootstrap/overrides' as *;
 @use '../themes/bootstrap/progress' as bp;
 
+@use '../variables/commons';
 @use '../variables/color';
 @use '../variables/components/progress-bars';
+@use '../mixins/utilities';
 
 .progress-bar {
   color: var(--text-color, progress-bars.$progress-bar-color);
+}
+
+@include utilities.high-contrast-mode() {
+  .progress {
+    border: commons.$border-width solid ButtonBorder;
+  }
+
+  .progress-bar[class] {
+    &,
+    & span {
+      background-color: Highlight !important;
+    }
+  }
 }


### PR DESCRIPTION
The Progressbar was nearly invisible, in Windows high-contrast-mode.
To activate this mode on Windows, click Alt + Shift + PrintScreen.