### PR TITLE
chore(variables): Refactors button font-sizes and removes deprecated font-size-map

### DIFF
--- a/.changeset/tall-moons-joke.md
+++ b/.changeset/tall-moons-joke.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/web-styles': major
+---
+
+Removes deprecated SCSS-variables $font-size-map, $font-size-sm, $font-size-rg and $font-size-lg from project, in favor of the new \$font-sizes map.

--- a/packages/web-styles/src/mixins/_button.scss
+++ b/packages/web-styles/src/mixins/_button.scss
@@ -22,7 +22,7 @@
 @mixin button-size($size: md) {
   height: map.get(button.$btn-height-map, $size);
   padding: 0 map.get(button.$btn-padding-x-map, $size);
-  font-size: map.get(type.$font-size-map, $size);
+  font-size: map.get(button.$btn-font-size-map, $size);
   gap: map.get(button.$btn-padding-x-map, $size) * 0.5;
 
   > .pi {

--- a/packages/web-styles/src/variables/_type.scss
+++ b/packages/web-styles/src/variables/_type.scss
@@ -149,19 +149,6 @@ $font-size-base: $font-size-regular !default;
 $font-weight-base: $font-weight-normal !default;
 $line-height-base: $line-height-regular !default;
 
-// !Deprecated! in favor of $font-sizes
-$font-size-sm: $font-size-tiny !default;
-$font-size-rg: $font-size-base !default;
-$font-size-lg: $font-size-bigger-regular !default;
-
-// !Deprecated! in favor of $font-sizes
-$font-size-map: (
-  'sm': $font-size-sm,
-  'rg': $font-size-rg,
-  'md': $font-size-base,
-  'lg': $font-size-lg,
-);
-
 $headings-margin-bottom: (spacing.$spacer * 0.5) !default;
 $headings-font-family: inherit !default;
 $headings-font-weight: 300 !default;

--- a/packages/web-styles/src/variables/components/_button.scss
+++ b/packages/web-styles/src/variables/components/_button.scss
@@ -43,6 +43,7 @@ $btn-padding-x-sm: spacing.$size-regular !default;
 $btn-animation-distance-sm: spacing.$size-mini !default;
 // CWF only
 $btn-height-sm: 2rem;
+$btn-font-size-sm: type.$font-size-tiny !default;
 $btn-icon-size-sm: spacing.$size-regular !default;
 
 // rg
@@ -51,6 +52,7 @@ $btn-padding-x-rg: spacing.$size-large !default;
 $btn-animation-distance-rg: 0.625rem !default;
 // CWF only
 $btn-height-rg: 2.5rem;
+$btn-font-size-rg: type.$font-size-regular !default;
 $btn-icon-size-rg: 1.125rem !default;
 
 // md
@@ -59,6 +61,7 @@ $btn-padding-x-md: spacing.$size-big !default;
 $btn-animation-distance-md: spacing.$size-small-regular !default;
 // CWF only
 $btn-height-md: 3rem;
+$btn-font-size-md: type.$font-size-regular !default;
 $btn-icon-size-md: spacing.$size-small-large !default;
 
 // lg
@@ -67,6 +70,7 @@ $btn-padding-x-lg: spacing.$size-bigger-big !default;
 $btn-animation-distance-lg: spacing.$size-regular !default;
 // CWF only
 $btn-height-lg: 3.5rem;
+$btn-font-size-lg: type.$font-size-bigger-regular !default;
 $btn-icon-size-lg: spacing.$size-large !default;
 
 // Available button sizes except the default, which is md
@@ -95,6 +99,12 @@ $btn-height-map: (
   'rg': $btn-height-rg,
   'md': $btn-height-md,
   'lg': $btn-height-lg,
+);
+$btn-font-size-map: (
+  'sm': $btn-font-size-sm,
+  'rg': $btn-font-size-rg,
+  'md': $btn-font-size-md,
+  'lg': $btn-font-size-lg,
 );
 $btn-icon-size-map: (
   'sm': $btn-icon-size-sm,


### PR DESCRIPTION
- The button component has now his own font-size-map.
- The global font-size-map and its dependant variables ($font-size-map, $font-size-sm, $font-size-rg, $font-size-lg) have been removed.