### PR TITLE
fix(web-styles): slash division deprecation warning

### DIFF
--- a/packages/web-styles/src/variables/components/_topic-teaser.scss
+++ b/packages/web-styles/src/variables/components/_topic-teaser.scss
@@ -1,11 +1,13 @@
+@use 'sass:list';
+
 $grid-keys-lower: (xs, sm, rg, md);
 $grid-keys-upper: (lg, xl);
 
 $topic-teaser-image-ratios: (
-  xs: 1 / 0.75,
-  sm: 1 / 0.75,
-  rg: 1 / 0.75,
-  md: 1 / 0.75,
+  xs: list.slash(1, 0.75),
+  sm: list.slash(1, 0.75),
+  rg: list.slash(1, 0.75),
+  md: list.slash(1, 0.75),
   lg: auto,
   xl: auto,
   xxl: auto,


### PR DESCRIPTION
Sass emits a deprecation warning for slash division on the following variables:

```shell
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1, 0.75) or calc(1 / 0.75)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
7 │   rg: 1 / 0.75,
  │       ^^^^^^^^
  ╵
    src\variables\components\_topic-teaser.scss 7:7  @use
    src\components\topic-teaser.scss 11:1            @use
    src\components\_index.scss 36:1                  @use
    src\post-portal.scss 9:1                         root stylesheet
```

The issue can be fixed by using `list.slash(x, y)` to declare the variable.