### PR TITLE
docs(toastr): improve documentation with accessibility hint

### DIFF
--- a/.changeset/funny-actors-cough.md
+++ b/.changeset/funny-actors-cough.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/web-demo': patch
+---
+
+Updated documentation on toastr alerts for improved accessibility user experience

--- a/packages/web-demo/src/app/bootstrap/components/alert/toast-demo/toast-demo.component.html
+++ b/packages/web-demo/src/app/bootstrap/components/alert/toast-demo/toast-demo.component.html
@@ -63,12 +63,8 @@
 <a href="https://www.npmjs.com/package/ngx-toastr" target="_blank" rel="noopener"
      class="btn btn-sm btn-primary">Ngx Bootstap Doc</a>
 </div>
-<div class="alert-container">
-  <div class="alert alert-warning">
-    <p>This is an example with cwf classes for ngx-toastr. To use it do <i>NOT</i> import toastr.css and toastr-bs4-alert as explained on ngx-toastr documentation.</p>
-    <p>ngx-toaster needs to be on version 9.2.0! [Version 10+ uses a different HTML Template. Other Versions have not been tested yet.]</p>
-  </div>
-</div>
+<p class="mb-3 mt-5">Screen reader output is a little better if the close button is disabled (alert messages can still be closed by clicking on them). Pass the following option to disable the close button:</p>
+<code class="d-block mt-3 mb-5" [highlight]="JSON.stringify(toastOptions, null, 2)" [languages]="['typescript']"></code>
 <section>
 <button class="btn btn-secondary btn-animated" (click)="showError()">
   <span>Show Toaster error</span>

--- a/packages/web-demo/src/app/bootstrap/components/alert/toast-demo/toast-demo.component.ts
+++ b/packages/web-demo/src/app/bootstrap/components/alert/toast-demo/toast-demo.component.ts
@@ -7,20 +7,24 @@ import {ToastrService} from "ngx-toastr";
   styleUrls: ['./toast-demo.component.scss']
 })
 export class ToastDemoComponent {
+  toastOptions = {
+    closeButton: false
+  }
+  JSON = JSON;
 
   constructor(private toastr: ToastrService) { }
 
   showError(){
-    this.toastr.error(null, "Error w/o message");
+    this.toastr.error(null, "Error w/o message", this.toastOptions);
   }
   showInfo(){
-    this.toastr.info("Information w/o title");
+    this.toastr.info("Information w/o title", '', this.toastOptions);
   }
   showSuccess(){
-    this.toastr.success("w/ message", "Success");
+    this.toastr.success("w/ message", "Success", this.toastOptions);
   }
   showWarning(){
-    this.toastr.warning("w/ message", "Warning");
+    this.toastr.warning("w/ message", "Warning", this.toastOptions);
   }
 
 }


### PR DESCRIPTION
The ngx-toastr supports adding a close button to toast alerts. The button however is announced as 'Close' in front of the actual message. The text is always English and cannot be configured. Disabling the close button just reads the alert message/title which gives a little better UX.