### PR TITLE
build(storybook): fix storybook startup error

### DIFF
--- a/packages/web-styles/package.json
+++ b/packages/web-styles/package.json
@@ -28,7 +28,7 @@
     "test": "jest",
     "test:ci": "jest",
     "start": "gulp watch",
-    "storybook": "start-storybook -p 6006 --quiet",
+    "storybook": "start-storybook -p 6006 --quiet --no-manager-cache",
     "build:storybook": "build-storybook"
   },
   "dependencies": {


### PR DESCRIPTION
When starting Storybook a second time (after the cache has been created once before) from the console on Windows, an error occurs:

`[Error: EBUSY: resource busy or locked, open 'C:\GIT\swisspost\common-web-frontend\packages\web-styles\node_modules\.cache\storybook\dev-server\325c8f456729b912b0d2134054eb7448-41ac79ddc5290d504ad69ef1fe8200a7'] { errno: -4082, code: 'EBUSY', syscall: 'open', path: 'C:\\GIT\\swisspost\\common-web-frontend\\packages\\web-styles\\node_modules\\.cache\\storybook\\dev-server\\325c8f456729b912b0d2134054eb7448-41ac79ddc5290d504ad69ef1fe8200a7' }`

This PR is kind of a workaround, to get rid of this error. Not a real and proper solution.
For further informations visit: https://issuehunt.io/r/storybookjs/storybook/issues/13795.