### PR TITLE
build(storybook): fix storybook onstartup and onsave error

### DIFF
--- a/.changeset/curvy-starfishes-explain.md
+++ b/.changeset/curvy-starfishes-explain.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/web-styles': patch
+---
+
+Fixed storybook EBUSY-error which occured on a npm cache file, sometimes when starting storybook and everytime when saving new content. This error caused the webpack server to crach.
+It's a workaround (for lack of alternative) and not a proper solution.

--- a/packages/web-styles/.storybook/main.js
+++ b/packages/web-styles/.storybook/main.js
@@ -15,5 +15,10 @@ module.exports = {
         }
       }
     }
-  ]
+  ],
+  // workaround, to prevent storybook from crashing, because of a EBUSY error, which occures on a npm cache file on storybook startup and when saving new content
+  managerWebpack: (config, options) => {
+    options.cache.set = () => Promise.resolve();
+    return config;
+  }
 }

--- a/packages/web-styles/package.json
+++ b/packages/web-styles/package.json
@@ -28,7 +28,7 @@
     "test": "jest",
     "test:ci": "jest",
     "start": "gulp watch",
-    "storybook": "start-storybook -p 6006 --quiet --no-manager-cache",
+    "storybook": "start-storybook -p 6006 --quiet",
     "build:storybook": "build-storybook"
   },
   "dependencies": {


### PR DESCRIPTION
When starting Storybook from the console on Windows, change a story and then hit save, an error occurs.
It's the same error who occured when starting up storybook a second time (https://github.com/swisspost/common-web-frontend/pull/247):

[Error: EBUSY: resource busy or locked, open 'C:\GIT\swisspost\common-web-frontend\packages\web-styles\node_modules.cache\storybook\dev-server\325c8f456729b912b0d2134054eb7448-41ac79ddc5290d504ad69ef1fe8200a7'] { errno: -4082, code: 'EBUSY', syscall: 'open', path: 'C:\GIT\swisspost\common-web-frontend\packages\web-styles\node_modules\.cache\storybook\dev-server\325c8f456729b912b0d2134054eb7448-41ac79ddc5290d504ad69ef1fe8200a7' }

The solution (workaround) was found here and was submitted by andrewiggins: https://issuehunt.io/r/storybookjs/storybook/issues/13795.