### PR TITLE
fix(intranet-header): Fix intranet-header styles

### DIFF
--- a/.changeset/eight-pants-trade.md
+++ b/.changeset/eight-pants-trade.md
@@ -1,5 +1,6 @@
 ---
 '@swisspost/web-styles': patch
+'@swisspost/intranet-header': patch
 ---
 
 Fixed line-height and background-color. Dropdowns inside the component intranet-header now have the same line-height as simple links. Invalid background-color rule has been fixed (none => transparent).

--- a/.changeset/eight-pants-trade.md
+++ b/.changeset/eight-pants-trade.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/web-styles': patch
+---
+
+Fixed line-height and background-color. Dropdowns inside the component intranet-header now have the same line-height as simple links. Invalid background-color rule has been fixed (none => transparent).

--- a/packages/web-styles/src/components/intranet-header/_top-navigation.scss
+++ b/packages/web-styles/src/components/intranet-header/_top-navigation.scss
@@ -14,12 +14,13 @@
   button.nav-link {
     @include button-mixins.reset-button();
     padding: nav.$nav-link-padding-y navbar.$navbar-nav-link-padding-x;
+    line-height: var(--body-line-height);
   }
 
   .nav-item > .nav-link {
     border-top: 4px solid transparent; // Border-Width according to PostWeb CSS
     border-bottom: 4px solid transparent; // Border-Width according to PostWeb CSS
-    background-color: none;
+    background-color: transparent;
     color: rgba(var(--black-rgb), 0.6);
 
     @include utilities.high-contrast-mode() {


### PR DESCRIPTION
The line-height of dropdowns inside a intranet-header component matches now the `line-height` of simple links.
This leads to equal heights for link- and dropdown-elements.
Furthermore, the invalid css-rule `background-color: none;` has been replaced with `background-color: transparent;`.