### PR TITLE
fix(form-range): add inputmode for inputfield for controlled range value

### DIFF
--- a/.changeset/calm-owls-ring.md
+++ b/.changeset/calm-owls-ring.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/web-demo': patch
+---
+
+Add html-property inputmode to controlledvalue inputfield, to improve userexperience. This will open a number-only Keyboard on mobile devices, when the user selects the inputfield.

--- a/packages/web-demo/src/app/bootstrap/components/form-range/form-range-custom-demo/form-range-custom-demo.component.html
+++ b/packages/web-demo/src/app/bootstrap/components/form-range/form-range-custom-demo/form-range-custom-demo.component.html
@@ -15,6 +15,6 @@
   </div>
   <div class="col-auto">
     <label class="form-label visually-hidden" for="rangeController">Range controller</label>
-    <input [(ngModel)]="controlledValue" class="form-control mw-giant" id="rangeController" type="text"/>
+    <input [(ngModel)]="controlledValue" class="form-control mw-giant" id="rangeController" type="text" inputmode="decimal"/>
   </div>
 </div>


### PR DESCRIPTION
The change lets mobiledevices open a number-only keyboard, when selecting the inputfield. What simplifies data entry for the user.