### PR TITLE
docs(multiple-select): update documentation on the size attribute

### DIFF
--- a/packages/web-demo/src/app/bootstrap/components/form-select-multiple/form-select-multiple-demo/form-select-multiple-demo.component.html
+++ b/packages/web-demo/src/app/bootstrap/components/form-select-multiple/form-select-multiple-demo/form-select-multiple-demo.component.html
@@ -10,7 +10,7 @@
 <div class="alert alert-info my-4">
   <p>In Safari on macOS, the size attribute only works as expected from 4+. This is a <a href="https://stackoverflow.com/questions/15760089/select-size-attribute-size-not-working-in-chrome-safari">known issue</a>.</p>
 </div>
-<select class="form-select" size="8" multiple aria-label="size 3 select example">
+<select class="form-select" size="8" multiple aria-label="size 8 select example">
   <option selected>Open this select menu</option>
   <option value="1">One</option>
   <option value="2">Two</option>

--- a/packages/web-demo/src/app/bootstrap/components/form-select-multiple/form-select-multiple-demo/form-select-multiple-demo.component.html
+++ b/packages/web-demo/src/app/bootstrap/components/form-select-multiple/form-select-multiple-demo/form-select-multiple-demo.component.html
@@ -1,4 +1,4 @@
-<h3>Using the <code>multiple</code> attribute</h3>
+<h3 class="mt-huge-r">Using the <code>multiple</code> attribute</h3>
 <select class="form-select" multiple aria-label="multiple select example">
   <option selected>Open this select menu</option>
   <option value="1">One</option>
@@ -6,10 +6,21 @@
   <option value="3">Three</option>
 </select>
 
-<h3>Using the <code>size</code> attribute</h3>
-<select class="form-select" size="3" aria-label="size 3 select example">
+<h3 class="mt-huge-r">Using the <code>size</code> attribute</h3>
+<div class="alert alert-info my-4">
+  <p>In Safari on macOS, the size attribute only works as expected from 4+. This is a <a href="https://stackoverflow.com/questions/15760089/select-size-attribute-size-not-working-in-chrome-safari">known issue</a>.</p>
+</div>
+<select class="form-select" size="8" multiple aria-label="size 3 select example">
   <option selected>Open this select menu</option>
   <option value="1">One</option>
   <option value="2">Two</option>
   <option value="3">Three</option>
+  <option value="4">Three</option>
+  <option value="5">Three</option>
+  <option value="6">Three</option>
+  <option value="7">Three</option>
+  <option value="8">Three</option>
+  <option value="9">Three</option>
+  <option value="10">Three</option>
+  <option value="11">Three</option>
 </select>

--- a/packages/web-demo/src/app/bootstrap/components/form-select-multiple/form-select-multiple-demo/form-select-multiple-demo.component.html
+++ b/packages/web-demo/src/app/bootstrap/components/form-select-multiple/form-select-multiple-demo/form-select-multiple-demo.component.html
@@ -15,12 +15,12 @@
   <option value="1">One</option>
   <option value="2">Two</option>
   <option value="3">Three</option>
-  <option value="4">Three</option>
-  <option value="5">Three</option>
-  <option value="6">Three</option>
-  <option value="7">Three</option>
-  <option value="8">Three</option>
-  <option value="9">Three</option>
-  <option value="10">Three</option>
-  <option value="11">Three</option>
+  <option value="4">Four</option>
+  <option value="5">Five</option>
+  <option value="6">Six</option>
+  <option value="7">Seven</option>
+  <option value="8">Eight</option>
+  <option value="9">Nine</option>
+  <option value="10">Ten</option>
+  <option value="11">Eleven</option>
 </select>

--- a/packages/web-demo/src/app/bootstrap/components/form-select-multiple/form-select-multiple-demo/form-select-multiple-demo.component.scss
+++ b/packages/web-demo/src/app/bootstrap/components/form-select-multiple/form-select-multiple-demo/form-select-multiple-demo.component.scss
@@ -1,5 +1,0 @@
-@use '@swisspost//web-styles/cwf';
-
-select + h3 {
-  margin-top: cwf.$size-large;
-}

--- a/packages/web-demo/src/app/bootstrap/components/form-select-multiple/form-select-multiple-demo/form-select-multiple-demo.component.ts
+++ b/packages/web-demo/src/app/bootstrap/components/form-select-multiple/form-select-multiple-demo/form-select-multiple-demo.component.ts
@@ -2,8 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-multiple-select-demo',
-  templateUrl: './form-select-multiple-demo.component.html',
-  styleUrls: ['./form-select-multiple-demo.component.scss']
+  templateUrl: './form-select-multiple-demo.component.html'
 })
 export class FormSelectMultipleDemoComponent {
 


### PR DESCRIPTION
The size attribute only works correctly from 4+ items in Safari. This is a known issue (https://stackoverflow.com/questions/15760089/select-size-attribute-size-not-working-in-chrome-safari).