### PR TITLE
fix(popover): add popover example with markup

### DIFF
--- a/.changeset/thin-horses-divide.md
+++ b/.changeset/thin-horses-divide.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/web-demo': patch
+---
+
+Adds popover example with markup.

--- a/packages/web-demo/src/app/ng-bootstrap/components/popover/popover-demo/popover-demo.component.html
+++ b/packages/web-demo/src/app/ng-bootstrap/components/popover/popover-demo/popover-demo.component.html
@@ -16,7 +16,7 @@
   </button>
 
   <ng-template #popContent>Vivamus sagittis lacus vel augue laoreet rutrum <a href="#">link</a> faucibus.</ng-template>
-  <ng-template #popTitle>Popover with <b>markup</b></ng-template>
+  <ng-template #popTitle>Popover with <strong>markup</strong></ng-template>
 
   <button type="button" class="btn btn-animated btn-secondary" [ngbPopover]="popContent" [popoverTitle]="popTitle">
     <span>Popover with markup</span>

--- a/packages/web-demo/src/app/ng-bootstrap/components/popover/popover-demo/popover-demo.component.html
+++ b/packages/web-demo/src/app/ng-bootstrap/components/popover/popover-demo/popover-demo.component.html
@@ -1,19 +1,24 @@
-<button type="button" class="btn btn-animated btn-secondary me-2" placement="top"
-        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on top">
-  <span>Popover on top</span>
-</button>
+<div class="d-flex flex-wrap gap-3">
+  <button type="button" class="btn btn-animated btn-secondary" placement="top" ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on top">
+    <span>Popover on top</span>
+  </button>
 
-<button type="button" class="btn btn-animated btn-secondary me-2" placement="right"
-        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on right">
+  <button type="button" class="btn btn-animated btn-secondary" placement="right" ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on right">
   <span>Popover on right</span>
-</button>
+  </button>
 
-<button type="button" class="btn btn-animated btn-secondary me-2" placement="bottom"
-        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on bottom">
+  <button type="button" class="btn btn-animated btn-secondary" placement="bottom" ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on bottom">
   <span>Popover on bottom</span>
-</button>
+  </button>
 
-<button type="button" class="btn btn-animated btn-secondary me-2" placement="left"
-        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on left">
+  <button type="button" class="btn btn-animated btn-secondary" placement="left" ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on left">
   <span>Popover on left</span>
-</button>
+  </button>
+
+  <ng-template #popContent>Vivamus sagittis lacus vel augue laoreet rutrum <a href="#">link</a> faucibus.</ng-template>
+  <ng-template #popTitle>Popover with <b>markup</b></ng-template>
+
+  <button type="button" class="btn btn-animated btn-secondary" [ngbPopover]="popContent" [popoverTitle]="popTitle">
+    <span>Popover with markup</span>
+  </button>
+</div>


### PR DESCRIPTION
Included a popover example with markup (e.g. link) and improved the gaps between the buttons.
The original error message is outdated. Links are framed with a browserspecific outline when they are focused.

**Chrome**
![image](https://user-images.githubusercontent.com/9716662/184831360-0c8a2e6e-83a2-4cab-9651-d75922dd2edd.png)

**Firefox**
![image](https://user-images.githubusercontent.com/9716662/184831513-a55e8fc3-c845-4e8b-a3d8-dab9b87f12d1.png)
