### PR TITLE
fix(alert): icons in high contrast mode

### DIFF
--- a/packages/web-styles/src/placeholders/_notifications.scss
+++ b/packages/web-styles/src/placeholders/_notifications.scss
@@ -90,7 +90,6 @@
 %notification-close-light {
   @extend .btn-close-white;
 }
-/* stylelint-enable */
 
 @each $name, $color, $icon in alert.$alert-list {
   $text-color: color-fn.get-contrast-color($color);
@@ -108,6 +107,7 @@
     } @else {
       @include icon-mixin.pi($icon);
       @include utilities.high-contrast-mode() {
+        // Specificity booster for the icon-mixin
         &[class] {
           @include icon-mixin.pi($icon, 'white');
 
@@ -136,3 +136,4 @@
     }
   }
 }
+/* stylelint-enable */

--- a/packages/web-styles/src/placeholders/_notifications.scss
+++ b/packages/web-styles/src/placeholders/_notifications.scss
@@ -108,20 +108,16 @@
     } @else {
       @include icon-mixin.pi($icon);
       @include utilities.high-contrast-mode() {
-        // use important here, so pi classes don't overwrite hcm styles
-        filter: none !important;
-        forced-color-adjust: none;
-        background-color: canvasText;
-        color: canvas;
+        &[class] {
+          @include icon-mixin.pi($icon, 'white');
 
-        .toast-close-button,
-        .btn-close {
-          filter: invert(100%);
+          // use important here, so pi classes don't overwrite hcm styles
+          filter: none !important;
         }
       }
     }
-    background-color: $background-color;
 
+    background-color: $background-color;
     color: $text-color;
 
     a,


### PR DESCRIPTION
Alerts with custom icons face the problem that those icons are black. Inversion techniques don't work because it would invert the whole alert. Creating white alternatives for all possible icons would blow up CSS size too much with current approaches so it's not viable. This approach just replaces custom icons with the default alert icon. This way, only a small set of white icons has to be created.